### PR TITLE
Revert "use temporary baseURL value until keychain.org is CNAME'd"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   url: 'https://keychain.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/kc-docs',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Reverts KeychainMDIP/kc-docs#1

Merge this PR once `keychain.org` points to GitHub pages via CNAME record.