### PR TITLE
Extend Prism

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,6 +135,14 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
+        additionalLanguages: ['bash', 'json'],
+        magicComments: [
+          // Remember to extend the default highlight class name as well!
+          {
+            className: 'code-block-terminal-command',
+            line: 'terminal-command',
+          },
+        ],
       },
       colorMode: {
         defaultMode: "dark",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,3 +36,8 @@
 [data-theme='dark'] footer {
   background-color: #000;
 }
+
+.code-block-terminal-command:before {
+  content: '$';
+  margin-right: 10px;
+}


### PR DESCRIPTION
- Expands the languages highlighted to include bash and json.
- Allows us to use a  comment in code blocks to prepend a `$`  character to the proceeding line, which is not included in the text copied with the code block copy button.

A future PR will expand this new functionality such that example output is also not included by the code block copy button.