### PR TITLE
Add plugin remark-github-admonitions-to-directives

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@
 // See: https://docusaurus.io/docs/api/docusaurus-config
 
 import {themes as prismThemes} from 'prism-react-renderer';
+import remarkGithubAdmonitionsToDirectives from "remark-github-admonitions-to-directives";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -45,6 +46,7 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/keychainmdip/kc-docs/tree/main/packages/create-docusaurus/templates/shared/',
+          beforeDefaultRemarkPlugins: [remarkGithubAdmonitionsToDirectives]
         },
         blog: {
           showReadingTime: true,
@@ -135,6 +137,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
+        additionalLanguages: ['bash', 'json']
       },
       colorMode: {
         defaultMode: "dark",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "remark-github-admonitions-to-directives": "^1.0.4"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7137,6 +7137,16 @@ remark-gfm@^4.0.0:
     remark-stringify "^11.0.0"
     unified "^11.0.0"
 
+remark-github-admonitions-to-directives@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/remark-github-admonitions-to-directives/-/remark-github-admonitions-to-directives-1.0.4.tgz#5e373f22c6aa49887e9db67af4e640a97e9a6b93"
+  integrity sha512-VLJNg722uOX8sC9rbsioGPR7Tt45oHvqUa58UDdptYylj2a7PmtBygvQUg93MUdPr2PrC/IJwC953+xWYDGprQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-directive "^3.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+
 remark-mdx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-3.0.1.tgz#8f73dd635c1874e44426e243f72c0977cf60e212"


### PR DESCRIPTION
This plugin allows Docusaurus to render callouts formatted for GitHub.