### PR TITLE
Callouts via frontmatter

### DIFF
--- a/src/components/globalCallouts/experimental.js
+++ b/src/components/globalCallouts/experimental.js
@@ -1,0 +1,18 @@
+import React from "react";
+import Admonition from '@theme/Admonition';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+export default function ExperimentalCallout() {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <Admonition type="warning">
+      <p>
+        This feature is currently in the experimental stage of development.
+        Do not use it in production environments or presume it is secure.
+        Expect breaking changes.
+      </p>
+    </Admonition>
+  );
+}
+
+

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import Unlisted from '@theme/Unlisted';
+import styles from './styles.module.css';
+import ExperimentalCallout from '@site/src/components/globalCallouts/experimental';
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+export default function DocItemLayout({children}) {
+  const docTOC = useDocTOC();
+  const {frontMatter} = useDoc();
+  const {
+    metadata: {unlisted},
+  } = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        {unlisted && <Unlisted />}
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>
+              {frontMatter.experimental == true ?
+                <><ExperimentalCallout/></>
+                : null
+              }
+              {children}
+            </DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
Resolves #9 

This PR demonstrates callouts added to the top of a page via frontmatter. When `expermintal: true` is present in a page's frontmatter, the admonition defined in `experimental.js` is displayed above the content on a page.

The initial form of this PR is marked as draft so we can discuss two main points:

1. Should this feature be expanded, either by having separate components for other callouts types, or by defining multiple outputs from the single component depending on the frontmatter key or value? For example, the frontmatter could be `callout: experimental/alpha/beta`, or use multiple keys each with a boolean value.

2. Review the contents of the experimental callout, as well as any other callouts defined based on the discussion of point # 1.

**Note:** This PR will conflict with #7 as both swizzle the DocItem component. Whichever is merged second will require a rebase.

Edit: Example of the render.
![image](https://github.com/KeychainMDIP/kc-docs/assets/2349184/d59b838b-9ba9-45a5-b71e-ee7515279804)
